### PR TITLE
PartialGuildApplicationCommandPermission::create() can take objects

### DIFF
--- a/Tests/Objects/Slash/PartialGuildApplicationCommandPermissionTest.php
+++ b/Tests/Objects/Slash/PartialGuildApplicationCommandPermissionTest.php
@@ -4,11 +4,19 @@ namespace Bytes\DiscordResponseBundle\Tests\Objects\Slash;
 
 use Bytes\Common\Faker\Discord\TestDiscordFakerTrait;
 use Bytes\DiscordResponseBundle\Enums\ApplicationCommandPermissionType;
+use Bytes\DiscordResponseBundle\Objects\Channel;
+use Bytes\DiscordResponseBundle\Objects\Interfaces\ApplicationCommandInterface;
+use Bytes\DiscordResponseBundle\Objects\Slash\ApplicationCommand;
 use Bytes\DiscordResponseBundle\Objects\Slash\ApplicationCommandPermission;
 use Bytes\DiscordResponseBundle\Objects\Slash\PartialGuildApplicationCommandPermission;
+use Bytes\ResponseBundle\Interfaces\IdInterface;
 use Generator;
+use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
+/**
+ *
+ */
 class PartialGuildApplicationCommandPermissionTest extends TestCase
 {
     use TestDiscordFakerTrait;
@@ -72,9 +80,11 @@ class PartialGuildApplicationCommandPermissionTest extends TestCase
     }
 
     /**
-     * 
+     * @dataProvider provideCommand
+     * @dataProvider provideId
+     * @param $commandId
      */
-    public function testCreate()
+    public function testCreate($commandId)
     {
         $commandId = $this->faker->snowflake();
 
@@ -90,5 +100,66 @@ class PartialGuildApplicationCommandPermissionTest extends TestCase
         $this->assertEquals($id, $object->getPermissions()[0]->getId());
         $this->assertEquals($type->value, $object->getPermissions()[0]->getType());
         $this->assertEquals($permission, $object->getPermissions()[0]->getPermission());
+    }
+
+    /**
+     * @return Generator
+     */
+    public function provideCommand()
+    {
+        $this->setupFaker();
+
+        $command = new ApplicationCommand();
+        $command->setId($this->faker->snowflake());
+        yield [$command];
+
+        $command = $this
+            ->getMockBuilder(ApplicationCommandInterface::class)
+            ->getMock();
+        $command->method('getCommandId')
+            ->willReturn($this->faker->snowflake());
+        yield [$command];
+
+        $command = $this
+            ->getMockBuilder(IdInterface::class)
+            ->getMock();
+        $command->method('getId')
+            ->willReturn($this->faker->snowflake());
+        yield [$command];
+    }
+
+    /**
+     * @dataProvider provideInvalidCommands
+     * @param $commandId
+     */
+    public function testCreateInvalidCommand($commandId)
+    {
+        $this->expectException(InvalidArgumentException::class);
+        PartialGuildApplicationCommandPermission::create($commandId, [
+            ApplicationCommandPermission::create(
+                $this->faker->snowflake(),
+                $this->faker->randomElement([ApplicationCommandPermissionType::role(), ApplicationCommandPermissionType::user()]),
+                $this->faker->boolean())
+        ]);
+    }
+
+    /**
+     * @return Generator
+     */
+    public function provideInvalidCommands()
+    {
+        $this->setupFaker();
+
+        yield [new ApplicationCommand()];
+        yield [new Channel()];
+
+        $command = new ApplicationCommand();
+        $command->setGuildId($this->faker->snowflake());
+        yield [$command];
+
+        $command = $this
+            ->getMockBuilder(ApplicationCommandInterface::class)
+            ->getMock();
+        yield [$command];
     }
 }

--- a/src/Objects/Slash/PartialGuildApplicationCommandPermission.php
+++ b/src/Objects/Slash/PartialGuildApplicationCommandPermission.php
@@ -2,9 +2,12 @@
 
 namespace Bytes\DiscordResponseBundle\Objects\Slash;
 
+use Bytes\DiscordResponseBundle\Objects\Interfaces\ApplicationCommandInterface;
 use Bytes\DiscordResponseBundle\Objects\Traits\ApplicationIdTrait;
 use Bytes\DiscordResponseBundle\Objects\Traits\GuildIDTrait;
 use Bytes\DiscordResponseBundle\Objects\Traits\IDTrait;
+use Bytes\DiscordResponseBundle\Services\IdNormalizer;
+use Bytes\ResponseBundle\Interfaces\IdInterface;
 use Doctrine\Common\Collections\ArrayCollection;
 
 /**
@@ -28,11 +31,12 @@ class PartialGuildApplicationCommandPermission
     private $permissions;
 
     /**
-     * @param string $id the id of the command
+     * @param ApplicationCommandInterface|IdInterface|string $id the id of the command
      * @param ApplicationCommandPermission[] $permissions
      * @return static
      */
-    public static function create(string $id, array $permissions = []): static {
+    public static function create(ApplicationCommandInterface|IdInterface|string $id, array $permissions = []): static {
+        $id = IdNormalizer::normalizeCommandIdArgument($id, 'The "id" argument is required and cannot be blank.');
         $static = new static();
         return $static->setId($id)
             ->setPermissions($permissions);


### PR DESCRIPTION
Take command ids of type ApplicationCommandInterface|IdInterface|string in PartialGuildApplicationCommandPermission