### PR TITLE
Prevent ChatInputCommand names and option names from having lowercase…

### DIFF
--- a/Tests/Objects/Application/Command/ChatInputCommandTest.php
+++ b/Tests/Objects/Application/Command/ChatInputCommandTest.php
@@ -21,7 +21,11 @@ use ReflectionException;
 use Symfony\Component\String\ByteString;
 use Symfony\Component\Validator\ConstraintViolationInterface;
 use Symfony\Component\Validator\Exception\ValidationFailedException;
+use UnexpectedValueException;
 
+/**
+ *
+ */
 class ChatInputCommandTest extends TestCase
 {
     use TestSerializerTrait, TestValidatorTrait, TestEnumTrait;
@@ -46,8 +50,8 @@ class ChatInputCommandTest extends TestCase
      */
     public function provideValidChatInputCommands()
     {
-        yield ['command' => ChatInputCommand::createChatCommand('sample', ByteString::fromRandom(), [
-            Option::create(ACOT::string(), 'Pick', 'Which is the word sample?', false, [
+        yield ['command' => ChatInputCommand::createChatCommand('sample', self::randomString(), [
+            Option::create(ACOT::string(), 'pick', 'Which is the word sample?', false, [
                 ApplicationCommandOptionChoice::create('Foo'),
                 ApplicationCommandOptionChoice::create('Bar'),
                 ApplicationCommandOptionChoice::create('Sample')
@@ -60,34 +64,54 @@ class ChatInputCommandTest extends TestCase
         $subcommands = [];
 
         foreach ($optionTypes as $index => $optionType) {
-            $subcommands[] = Option::createSubcommand(ByteString::fromRandom(), ByteString::fromRandom(), [
-                Option::create($optionType, ByteString::fromRandom(), ByteString::fromRandom(), $index % 2 == 1 ? true : false)
+            $subcommands[] = Option::createSubcommand(self::randomValidName(), self::randomString(), [
+                Option::create($optionType, self::randomValidName(), self::randomString(), $index % 2 == 1 ? true : false)
             ]);
         }
 
-        $subcommands[] = Option::createSubcommand(ByteString::fromRandom(), ByteString::fromRandom(), [
-            Option::create(ACOT::string(), ByteString::fromRandom(), ByteString::fromRandom(), true, [
-                ApplicationCommandOptionChoice::create(ByteString::fromRandom()),
-                ApplicationCommandOptionChoice::create(ByteString::fromRandom()),
-                ApplicationCommandOptionChoice::create(ByteString::fromRandom()),
-                ApplicationCommandOptionChoice::create(ByteString::fromRandom()),
-                ApplicationCommandOptionChoice::create(ByteString::fromRandom()),
-                ApplicationCommandOptionChoice::create(ByteString::fromRandom()),
-                ApplicationCommandOptionChoice::create(ByteString::fromRandom()),
-                ApplicationCommandOptionChoice::create(ByteString::fromRandom()),
-                ApplicationCommandOptionChoice::create(ByteString::fromRandom()),
-                ApplicationCommandOptionChoice::create(ByteString::fromRandom()),
+        $subcommands[] = Option::createSubcommand(self::randomValidName(), self::randomString(), [
+            Option::create(ACOT::string(), self::randomValidName(), self::randomString(), true, [
+                ApplicationCommandOptionChoice::create(self::randomString()),
+                ApplicationCommandOptionChoice::create(self::randomString()),
+                ApplicationCommandOptionChoice::create(self::randomString()),
+                ApplicationCommandOptionChoice::create(self::randomString()),
+                ApplicationCommandOptionChoice::create(self::randomString()),
+                ApplicationCommandOptionChoice::create(self::randomString()),
+                ApplicationCommandOptionChoice::create(self::randomString()),
+                ApplicationCommandOptionChoice::create(self::randomString()),
+                ApplicationCommandOptionChoice::create(self::randomString()),
+                ApplicationCommandOptionChoice::create(self::randomString()),
             ])
         ]);
 
-        yield ['command' => ChatInputCommand::createChatCommand(ByteString::fromRandom(), ByteString::fromRandom(), $subcommands)];
+        yield ['command' => ChatInputCommand::createChatCommand(self::randomValidName(), self::randomString(), $subcommands)];
 
         $groups = [];
         foreach (range(1, 3) as $index) {
-            $groups[] = Option::createSubcommandGroup(ByteString::fromRandom(), ByteString::fromRandom(), $subcommands);
+            $groups[] = Option::createSubcommandGroup(self::randomValidName(), self::randomString(), $subcommands);
         }
 
-        yield ['command' => ChatInputCommand::createChatCommand(ByteString::fromRandom(), ByteString::fromRandom(), $groups)];
+        yield ['command' => ChatInputCommand::createChatCommand(self::randomValidName(), self::randomString(), $groups)];
+    }
+
+    /**
+     * Returns a valid random Discord string
+     * @param int $length
+     * @return string
+     */
+    private static function randomString(int $length = 16): string
+    {
+        return ByteString::fromRandom(length: $length)->toString();
+    }
+
+    /**
+     * Returns a valid random Discord name (lowercase letters and numbers)
+     * @param int $length
+     * @return string
+     */
+    private static function randomValidName(int $length = 16): string
+    {
+        return ByteString::fromRandom(length: $length, alphabet: '123456789abcdefghijkmnopqrstuvwxyz')->toString();
     }
 
     /**
@@ -101,10 +125,13 @@ class ChatInputCommandTest extends TestCase
         $this->assertStringNotContainsString('nameDescriptionValueCharacterLength', $json);
     }
 
+    /**
+     *
+     */
     public function testCreateNameTooLong()
     {
         // Name is too long
-        $command = ChatInputCommand::createChatCommand(ByteString::fromRandom(33), ByteString::fromRandom());
+        $command = ChatInputCommand::createChatCommand(self::randomValidName(33), self::randomString());
 
         try {
             $this->validate($command);
@@ -122,11 +149,14 @@ class ChatInputCommandTest extends TestCase
         }
     }
 
+    /**
+     *
+     */
     public function testCreateNameInvalidCharacter()
     {
 
         // Name is right length but has an invalid character
-        $command = ChatInputCommand::createChatCommand(ByteString::fromRandom(10) . ' a', ByteString::fromRandom());
+        $command = ChatInputCommand::createChatCommand(self::randomValidName(10) . ' a', self::randomString());
 
         try {
             $this->validate($command);
@@ -140,11 +170,88 @@ class ChatInputCommandTest extends TestCase
         }
     }
 
+    /**
+     *
+     */
+    public function testCreateNameHasUppercase()
+    {
+        $command = ChatInputCommand::createChatCommand('Sample', self::randomString());
+
+        try {
+            $this->validate($command);
+        } catch (ValidationFailedException $exception) {
+            $this->assertEquals(1, count($exception->getViolations()));
+
+            /** @var ConstraintViolationInterface $violation */
+            $violation = $exception->getViolations()[0];
+            $this->assertEquals('Your name may not contain uppercase characters.', $violation->getMessage());
+            $this->assertEquals('name', $violation->getPropertyPath());
+        }
+    }
+
+    /**
+     *
+     */
+    public function testCreateOptionNameHasUppercase()
+    {
+        $command = ChatInputCommand::createChatCommand('sample', self::randomString(), [
+            Option::create(ACOT::string(), 'Pick', 'Which is the word sample?', false, [
+                ApplicationCommandOptionChoice::create('Foo'),
+                ApplicationCommandOptionChoice::create('Bar'),
+                ApplicationCommandOptionChoice::create('Sample')
+            ])
+        ]);
+
+        try {
+            $this->validate($command);
+        } catch (ValidationFailedException $exception) {
+            $this->assertEquals(1, count($exception->getViolations()));
+
+            /** @var ConstraintViolationInterface $violation */
+            $violation = $exception->getViolations()[0];
+            $this->assertEquals('Your option name may not contain uppercase characters.', $violation->getMessage());
+            $this->assertEquals('options[0].name', $violation->getPropertyPath());
+        }
+    }
+
+    /**
+     *
+     */
+    public function testCreateNameAndOptionNameHasUppercase()
+    {
+        $command = ChatInputCommand::createChatCommand('Sample', self::randomString(), [
+            Option::create(ACOT::string(), 'Pick', 'Which is the word sample?', false, [
+                ApplicationCommandOptionChoice::create('Foo'),
+                ApplicationCommandOptionChoice::create('Bar'),
+                ApplicationCommandOptionChoice::create('Sample')
+            ])
+        ]);
+
+        try {
+            $this->validate($command);
+        } catch (ValidationFailedException $exception) {
+            $this->assertEquals(2, count($exception->getViolations()));
+
+            /** @var ConstraintViolationInterface $violation */
+            $violation = $exception->getViolations()[0];
+            $this->assertEquals('Your name may not contain uppercase characters.', $violation->getMessage());
+            $this->assertEquals('name', $violation->getPropertyPath());
+
+            /** @var ConstraintViolationInterface $violation */
+            $violation = $exception->getViolations()[1];
+            $this->assertEquals('Your option name may not contain uppercase characters.', $violation->getMessage());
+            $this->assertEquals('options[0].name', $violation->getPropertyPath());
+        }
+    }
+
+    /**
+     *
+     */
     public function testCreateDescriptionTooLong()
     {
 
         // Description is too long
-        $command = ChatInputCommand::createChatCommand(ByteString::fromRandom(), ByteString::fromRandom(101));
+        $command = ChatInputCommand::createChatCommand(self::randomValidName(), self::randomString(101));
 
         try {
             $this->validate($command);
@@ -158,12 +265,15 @@ class ChatInputCommandTest extends TestCase
         }
     }
 
+    /**
+     *
+     */
     public function testCreateOptionNameTooLong()
     {
 
         // Subcommand isn't valid - name too long
-        $command = ChatInputCommand::createChatCommand('sample', ByteString::fromRandom(), [
-            Option::create(ACOT::string(), ByteString::fromRandom(33), 'Which is the word sample?', false, [
+        $command = ChatInputCommand::createChatCommand('sample', self::randomString(), [
+            Option::create(ACOT::string(), self::randomValidName(33), 'Which is the word sample?', false, [
                 ApplicationCommandOptionChoice::create('Foo'),
                 ApplicationCommandOptionChoice::create('Bar'),
                 ApplicationCommandOptionChoice::create('Sample')
@@ -186,12 +296,15 @@ class ChatInputCommandTest extends TestCase
         }
     }
 
+    /**
+     *
+     */
     public function testCreateOptionNameInvalidCharacter()
     {
 
         // Subcommand isn't valid - name is right length but has an invalid character
-        $command = ChatInputCommand::createChatCommand('sample', ByteString::fromRandom(), [
-            Option::create(ACOT::string(), ByteString::fromRandom(10) . ' a', ByteString::fromRandom(), false, [
+        $command = ChatInputCommand::createChatCommand('sample', self::randomString(), [
+            Option::create(ACOT::string(), self::randomValidName(10) . ' a', self::randomString(), false, [
                 ApplicationCommandOptionChoice::create('Foo'),
                 ApplicationCommandOptionChoice::create('Bar'),
                 ApplicationCommandOptionChoice::create('Sample')
@@ -210,12 +323,15 @@ class ChatInputCommandTest extends TestCase
         }
     }
 
+    /**
+     *
+     */
     public function testCreateOptionDescriptionTooLong()
     {
 
         // Subcommand isn't valid - description is too long
-        $command = ChatInputCommand::createChatCommand(ByteString::fromRandom(), ByteString::fromRandom(), [
-            Option::create(ACOT::string(), ByteString::fromRandom(), ByteString::fromRandom(101), false, [
+        $command = ChatInputCommand::createChatCommand(self::randomValidName(), self::randomString(), [
+            Option::create(ACOT::string(), self::randomValidName(), self::randomString(101), false, [
                 ApplicationCommandOptionChoice::create('Foo'),
                 ApplicationCommandOptionChoice::create('Bar'),
                 ApplicationCommandOptionChoice::create('Sample')
@@ -234,18 +350,21 @@ class ChatInputCommandTest extends TestCase
         }
     }
 
+    /**
+     * @throws ReflectionException
+     */
     public function testForTooManySubcommands()
     {
         $optionTypes = $this->getCommandOptionTypes();
         $subcommands = [];
         foreach (range(1, 26) as $index => $optionType) {
-            $subcommands[] = Option::createSubcommand(ByteString::fromRandom(5), ByteString::fromRandom(5), [
-                Option::create(Arr::random($optionTypes), ByteString::fromRandom(5), ByteString::fromRandom(5), $index % 2 == 1 ? true : false)
+            $subcommands[] = Option::createSubcommand(self::randomValidName(5), self::randomString(5), [
+                Option::create(Arr::random($optionTypes), self::randomValidName(5), self::randomString(5), $index % 2 == 1 ? true : false)
             ]);
         }
 
         try {
-            $this->validate(ChatInputCommand::createChatCommand(ByteString::fromRandom(), ByteString::fromRandom(), $subcommands));
+            $this->validate(ChatInputCommand::createChatCommand(self::randomValidName(), self::randomString(), $subcommands));
         } catch (ValidationFailedException $exception) {
             $this->assertEquals(1, count($exception->getViolations()));
 
@@ -268,23 +387,26 @@ class ChatInputCommandTest extends TestCase
         return $this->commandOptionTypes;
     }
 
+    /**
+     * @throws ReflectionException
+     */
     public function testForTooManySubcommandGroups()
     {
         $optionTypes = $this->getCommandOptionTypes();
         $subcommands = [];
         foreach (range(1, 2) as $index => $optionType) {
-            $subcommands[] = Option::createSubcommand(ByteString::fromRandom(5), ByteString::fromRandom(5), [
-                Option::create(Arr::random($optionTypes), ByteString::fromRandom(5), ByteString::fromRandom(5), $index % 2 == 1 ? true : false)
+            $subcommands[] = Option::createSubcommand(self::randomValidName(5), self::randomString(5), [
+                Option::create(Arr::random($optionTypes), self::randomValidName(5), self::randomString(5), $index % 2 == 1 ? true : false)
             ]);
         }
 
         $groups = [];
         foreach (range(1, 26) as $index) {
-            $groups[] = Option::createSubcommandGroup(ByteString::fromRandom(5), ByteString::fromRandom(5), $subcommands);
+            $groups[] = Option::createSubcommandGroup(self::randomValidName(5), self::randomString(5), $subcommands);
         }
 
         try {
-            $this->validate(ChatInputCommand::createChatCommand(ByteString::fromRandom(), ByteString::fromRandom(), $groups));
+            $this->validate(ChatInputCommand::createChatCommand(self::randomValidName(), self::randomString(), $groups));
         } catch (ValidationFailedException $exception) {
             $this->assertEquals(1, count($exception->getViolations()));
 
@@ -295,17 +417,20 @@ class ChatInputCommandTest extends TestCase
         }
     }
 
+    /**
+     * @throws ReflectionException
+     */
     public function testForTooManyChoices()
     {
         $optionTypes = $this->getCommandOptionTypes();
         $groups = [];
         foreach (range(1, 26) as $index) {
-            $groups[] = ApplicationCommandOptionChoice::create(ByteString::fromRandom(5));
+            $groups[] = ApplicationCommandOptionChoice::create(self::randomValidName(5));
         }
 
         try {
-            $this->validate(ChatInputCommand::createChatCommand(ByteString::fromRandom(5), ByteString::fromRandom(5), [
-                Option::create(Arr::random($optionTypes), ByteString::fromRandom(5), ByteString::fromRandom(5), false, $groups)
+            $this->validate(ChatInputCommand::createChatCommand(self::randomValidName(5), self::randomString(5), [
+                Option::create(Arr::random($optionTypes), self::randomValidName(5), self::randomString(5), false, $groups)
             ]));
         } catch (ValidationFailedException $exception) {
             $this->assertEquals(1, count($exception->getViolations()));
@@ -317,21 +442,24 @@ class ChatInputCommandTest extends TestCase
         }
     }
 
+    /**
+     * @throws ReflectionException
+     */
     public function testForNameDescriptionValuesTooLong()
     {
         $optionTypes = $this->getCommandOptionTypes();
         $groups = [];
         foreach (range(1, 25) as $index) {
-            $groups[] = ApplicationCommandOptionChoice::create(ByteString::fromRandom(30));
+            $groups[] = ApplicationCommandOptionChoice::create(self::randomString(30));
         }
 
         try {
-            $this->validate(ChatInputCommand::createChatCommand(ByteString::fromRandom(), ByteString::fromRandom(), [
-                Option::create(Arr::random($optionTypes), ByteString::fromRandom(), ByteString::fromRandom(), false, $groups),
-                Option::create(Arr::random($optionTypes), ByteString::fromRandom(), ByteString::fromRandom(), false, $groups),
-                Option::create(Arr::random($optionTypes), ByteString::fromRandom(), ByteString::fromRandom(), false, $groups),
-                Option::create(Arr::random($optionTypes), ByteString::fromRandom(), ByteString::fromRandom(), false, $groups),
-                Option::create(Arr::random($optionTypes), ByteString::fromRandom(), ByteString::fromRandom(), false, $groups),
+            $this->validate(ChatInputCommand::createChatCommand(self::randomValidName(), self::randomString(), [
+                Option::create(Arr::random($optionTypes), self::randomValidName(), self::randomString(), false, $groups),
+                Option::create(Arr::random($optionTypes), self::randomValidName(), self::randomString(), false, $groups),
+                Option::create(Arr::random($optionTypes), self::randomValidName(), self::randomString(), false, $groups),
+                Option::create(Arr::random($optionTypes), self::randomValidName(), self::randomString(), false, $groups),
+                Option::create(Arr::random($optionTypes), self::randomValidName(), self::randomString(), false, $groups),
             ]));
         } catch (ValidationFailedException $exception) {
             $this->assertEquals(1, count($exception->getViolations()));
@@ -341,15 +469,6 @@ class ChatInputCommandTest extends TestCase
             $this->assertStringMatchesFormat('Your combined name, description, and value properties for each command and its subcommands and groups (%d) cannot be longer than 4000 characters', $violation->getMessage());
             $this->assertEquals('nameDescriptionValueCharacterLengthRecursively', $violation->getPropertyPath());
         }
-    }
-
-    /**
-     * This method is called after each test.
-     */
-    protected function tearDown(): void
-    {
-        parent::tearDown();
-        $this->commandOptionTypes = null;
     }
 
     /**
@@ -385,7 +504,7 @@ class ChatInputCommandTest extends TestCase
      */
     public function testSetTypeInvalid()
     {
-        $this->expectException(\UnexpectedValueException::class);
+        $this->expectException(UnexpectedValueException::class);
         $cmd = new ChatInputCommand();
         $cmd->setType(-5);
     }
@@ -415,5 +534,14 @@ class ChatInputCommandTest extends TestCase
 
         yield ['45984847365'];
         yield [$faker->snowflake()];
+    }
+
+    /**
+     * This method is called after each test.
+     */
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        $this->commandOptionTypes = null;
     }
 }

--- a/src/Objects/Application/Command/ChatInputCommand.php
+++ b/src/Objects/Application/Command/ChatInputCommand.php
@@ -37,6 +37,11 @@ class ChatInputCommand extends ApplicationCommand
      *      maxMessage = "Your name cannot be longer than {{ limit }} characters"
      * )
      * @Assert\Regex("/^[\w-]{1,32}$/")
+     * @Assert\Regex(
+     *     pattern="/([A-Z].*)/",
+     *     match=false,
+     *     message="Your name may not contain uppercase characters."
+     * )
      */
     private $name;
 

--- a/src/Objects/Slash/ApplicationCommandOption.php
+++ b/src/Objects/Slash/ApplicationCommandOption.php
@@ -36,6 +36,11 @@ class ApplicationCommandOption implements NameInterface
      *      maxMessage = "Your name cannot be longer than {{ limit }} characters"
      * )
      * @Assert\Regex("/^[\w-]{1,32}$/")
+     * @Assert\Regex(
+     *     pattern="/([A-Z].*)/",
+     *     match=false,
+     *     message="Your option name may not contain uppercase characters."
+     * )
      */
     private $name;
 


### PR DESCRIPTION
… characters

This was not originally the requirement from Discord, but is now.

Note: while this is a breaking change, it's also a requirement from Discord already enforced, so we will release this as a build increment only.